### PR TITLE
fix: Improve badge ID matching by using case-insensitive and trimmed comparison

### DIFF
--- a/src/components/providers/badge-provider.tsx
+++ b/src/components/providers/badge-provider.tsx
@@ -46,7 +46,7 @@ export const BadgeProvider: React.FC<{
   };
 
   const checkClaimStatus = (badge: BadgeWithCollectedStatus) => {
-    const condition = CLAIM_CONDITIONS.find((c) => c.badgeId === badge.id);
+    const condition = CLAIM_CONDITIONS.find((c) => c.badgeId.toLowerCase().trim() === badge.id.toLowerCase().trim());
 
     if (!condition) {
       // If no condition is found by badge has been collected, show Claimed

--- a/src/constants/claim-conditions.ts
+++ b/src/constants/claim-conditions.ts
@@ -37,7 +37,7 @@ export const CLAIM_CONDITIONS: ClaimCondition[] = [
     badgeId: "0xd1b3f1e744d705b8c52faa3c6f769ddbd6ffe9d8",
   },
   {
-    badgeId: "0x002ff408b13a677f0d5eefe0f5c523f967bd0d5A ",
+    badgeId: "0x002ff408b13a677f0d5eefe0f5c523f967bd0d5a",
     mustOwnBadge: "0x3e9af5c6ae7f7936c629de669a0e3295f3266fb0",
     claimableFrom: new Date("2025-02-26T00:00:00Z"),
     claimableTo: new Date("2025-02-26T23:59:59Z"),

--- a/src/constants/claim-conditions.ts
+++ b/src/constants/claim-conditions.ts
@@ -41,6 +41,6 @@ export const CLAIM_CONDITIONS: ClaimCondition[] = [
     mustOwnBadge: "0x3e9af5c6ae7f7936c629de669a0e3295f3266fb0",
     claimableFrom: new Date("2025-02-26T00:00:00Z"),
     claimableTo: new Date("2025-02-26T23:59:59Z"),
-    hide: false
-  }
+    hide: false,
+  },
 ];

--- a/src/lib/openformat.ts
+++ b/src/lib/openformat.ts
@@ -445,7 +445,7 @@ export async function claimBadge(
     }
 
     // Find the badge and its claim condition
-    const condition = CLAIM_CONDITIONS.find((c) => c.badgeId === badgeId);
+    const condition = CLAIM_CONDITIONS.find((c) => c.badgeId.toLowerCase().trim() === badgeId.toLowerCase().trim());
 
     if (!condition) {
       return { success: false, message: "Badge is not claimable due to missing conditions." };


### PR DESCRIPTION
The subgraph is case-sensitive. This PR adds `toLowerCase()` and `trim()` to badge IDs for comparisons.